### PR TITLE
Release v1.18.0: Configurable candle intervals for daytrading

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -110,6 +110,19 @@ class Settings(BaseSettings):
         description="Seconds between trading checks (fallback when adaptive disabled)"
     )
 
+    # Candle Settings for Technical Analysis
+    candle_interval: str = Field(
+        default="ONE_HOUR",
+        pattern="^(ONE_MINUTE|FIVE_MINUTE|FIFTEEN_MINUTE|THIRTY_MINUTE|ONE_HOUR|TWO_HOUR|SIX_HOUR|ONE_DAY)$",
+        description="Candlestick granularity for technical analysis"
+    )
+    candle_limit: int = Field(
+        default=100,
+        ge=50,
+        le=500,
+        description="Number of candles to fetch for indicator calculation"
+    )
+
     # Adaptive Interval Settings
     adaptive_interval_enabled: bool = Field(
         default=True,

--- a/src/daemon/runner.py
+++ b/src/daemon/runner.py
@@ -535,8 +535,8 @@ class TradingDaemon:
             current_price = self.client.get_current_price(self.settings.trading_pair)
             candles = self.client.get_candles(
                 self.settings.trading_pair,
-                granularity="ONE_HOUR",
-                limit=100,
+                granularity=self.settings.candle_interval,
+                limit=self.settings.candle_limit,
             )
 
             # Persist candles to rate_history (separate try/except - don't affect trading)
@@ -547,7 +547,7 @@ class TradingDaemon:
                         candles=candle_dicts,
                         symbol=self.settings.trading_pair,
                         exchange=self.exchange_name,
-                        interval="1h",
+                        interval=self.settings.candle_interval,
                         is_paper=self.settings.is_paper_trading,
                     )
                     if inserted > 0:
@@ -1530,8 +1530,8 @@ class TradingDaemon:
             current_price = self.client.get_current_price(self.settings.trading_pair)
             candles = self.client.get_candles(
                 self.settings.trading_pair,
-                granularity="ONE_HOUR",
-                limit=100,
+                granularity=self.settings.candle_interval,
+                limit=self.settings.candle_limit,
             )
 
             # Calculate indicators
@@ -1934,7 +1934,7 @@ class TradingDaemon:
             candles = self.client.get_candles(
                 self.settings.trading_pair,
                 self.settings.candle_interval,
-                limit=100,
+                limit=self.settings.candle_limit,
             )
             self._create_trailing_stop(
                 entry_price=avg_cost,

--- a/src/version.py
+++ b/src/version.py
@@ -1,3 +1,3 @@
 """Version information for claude-trader."""
 
-__version__ = "1.17.5"
+__version__ = "1.18.0"


### PR DESCRIPTION
## Summary

- **Configurable candle intervals**: Add `CANDLE_INTERVAL` and `CANDLE_LIMIT` settings to enable switching between swingtrading (ONE_HOUR) and daytrading (FIFTEEN_MINUTE)
- **Momentum mode**: Signal scorer now detects and rides sustained uptrends (v1.17.0)
- **Comprehensive test suite**: 11 new test files with ~9000 lines of tests
- **Indicator improvements**: Wilder's smoothing, documentation, bug fixes

## Key Changes

| Feature | Description |
|---------|-------------|
| `CANDLE_INTERVAL` | Configurable granularity (ONE_MINUTE to ONE_DAY) |
| `CANDLE_LIMIT` | Configurable candle history (50-500) |
| `SIGNAL_THRESHOLD` | Lowered to 50 for daytrading (was 60) |
| Momentum mode | Reduces overbought penalties during sustained uptrends |

## Test Plan

- [ ] Verify paper trading starts with new settings
- [ ] Confirm 15-minute candles are fetched
- [ ] Monitor for ~2-5 trades/day (vs 0/week before)
- [ ] Run test suite: `pytest tests/`

## .env Changes Required on Server

```env
CANDLE_INTERVAL=FIFTEEN_MINUTE
CANDLE_LIMIT=100
SIGNAL_THRESHOLD=50
RSI_OVERSOLD=38
RSI_OVERBOUGHT=62
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)