### PR TITLE
Add GitHub Sponsors link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: TheodorStorm


### PR DESCRIPTION
## Summary
- Adds `.github/FUNDING.yml` to display a "Sponsor" button on the repository page
- Links to https://github.com/sponsors/TheodorStorm

🤖 Generated with [Claude Code](https://claude.com/claude-code)