### PR TITLE
Add configurable AI failure mode for trade review (v1.22.21)

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -34,6 +34,12 @@ class VetoAction(str, Enum):
     INFO = "info"      # Log but proceed with trade
 
 
+class AIFailureMode(str, Enum):
+    """Behavior when AI trade review fails or times out."""
+    OPEN = "open"    # Proceed with trade (current behavior, fail-open)
+    SAFE = "safe"    # Skip trade if AI unreachable (fail-safe)
+
+
 class Settings(BaseSettings):
     """Main application settings with validation."""
 
@@ -310,6 +316,10 @@ class Settings(BaseSettings):
     ai_review_all: bool = Field(
         default=False,
         description="Review ALL decisions with AI (for debugging/testing)"
+    )
+    ai_failure_mode: AIFailureMode = Field(
+        default=AIFailureMode.OPEN,
+        description="Behavior when AI review fails: open (proceed with trade) or safe (skip trade)"
     )
 
     # Hourly Market Analysis (uses same multi-agent system as trade reviews)

--- a/src/version.py
+++ b/src/version.py
@@ -1,3 +1,3 @@
 """Version information for claude-trader."""
 
-__version__ = "1.22.17"
+__version__ = "1.22.21"


### PR DESCRIPTION
## Summary
Adds `AIFailureMode` enum (OPEN/SAFE) to configure bot behavior when AI trade review fails or times out:

- **OPEN (default)**: Proceed with trade (fail-open, current behavior for backward compatibility)
- **SAFE**: Skip trade if AI is unreachable (fail-safe for live trading scenarios)

## Features
- 15-minute notification cooldown to prevent Telegram spam during AI outages
- Uses timezone-aware `datetime.now(timezone.utc)` (Python 3.12+ compatible)
- Full stack trace logging on AI failures (`exc_info=True`)
- Ephemeral in-memory cooldown state (documented, intentionally resets on restart)
- Four comprehensive unit tests with proper position_sizer mocking

## Config
Set `AI_FAILURE_MODE=safe` in environment to enable fail-safe mode.

## Files Changed
- `config/settings.py` - Added AIFailureMode enum and setting
- `src/daemon/runner.py` - Exception handler with failure mode check, cooldown, and improved logging
- `tests/test_trading_daemon.py` - 4 new tests for both modes and cooldown
- `src/version.py` - Bumped to v1.22.21

## Review Feedback Addressed
- [x] Fixed deprecated `datetime.utcnow()` → `datetime.now(timezone.utc)`
- [x] Added `exc_info=True` for full stack trace logging
- [x] Added comment explaining ephemeral cooldown state
- [x] Added comment in OPEN mode test explaining test scope

## Test plan
- [x] All 30 daemon tests pass
- [x] No deprecation warnings
- [x] Precommit validation passed
- [ ] Verify OPEN mode continues trades after AI failure
- [ ] Verify SAFE mode skips trades after AI failure
- [ ] Verify notification cooldown prevents spam