### PR TITLE
Fix runtime errors: database session and Kraken granularity (v1.28.9)

### DIFF
--- a/src/daemon/runner.py
+++ b/src/daemon/runner.py
@@ -693,7 +693,9 @@ class TradingDaemon:
             return "neutral", "neutral", "neutral"
 
         daily = self._get_timeframe_trend("ONE_DAY", self.settings.mtf_daily_cache_minutes)
-        six_hour = self._get_timeframe_trend("SIX_HOUR", self.settings.mtf_6h_cache_minutes)
+        # Use FOUR_HOUR instead of SIX_HOUR for broader exchange compatibility
+        # (Kraken doesn't support 6-hour candles, only 4-hour)
+        six_hour = self._get_timeframe_trend("FOUR_HOUR", self.settings.mtf_6h_cache_minutes)
 
         # Combine: both must agree for strong bias
         if daily == "bullish" and six_hour == "bullish":
@@ -736,7 +738,7 @@ class TradingDaemon:
         """
         try:
             breakdown = signal_result.breakdown
-            with self.db.get_session() as session:
+            with self.db.session() as session:
                 history = SignalHistory(
                     symbol=self.settings.trading_pair,
                     is_paper=self.settings.is_paper_trading,
@@ -786,7 +788,7 @@ class TradingDaemon:
             return
 
         try:
-            with self.db.get_session() as session:
+            with self.db.session() as session:
                 session.query(SignalHistory).filter(
                     SignalHistory.id == signal_id
                 ).update({"trade_executed": True})

--- a/src/version.py
+++ b/src/version.py
@@ -1,3 +1,3 @@
 """Version information for claude-trader."""
 
-__version__ = "1.28.8"
+__version__ = "1.28.9"


### PR DESCRIPTION
## Summary
Hotfix for two runtime errors discovered after deploying v1.28.8.

## Fixes

### 1. Database Session Method Name
**Error:** `'Database' object has no attribute 'get_session'`

**Fix:** Changed `self.db.get_session()` to `self.db.session()` in:
- `_store_signal_history()` 
- `_mark_signal_trade_executed()`

### 2. Kraken SIX_HOUR Granularity Not Supported
**Error:** `Kraken API error: EGeneral:Invalid arguments` for SIX_HOUR timeframe

**Fix:** Changed from SIX_HOUR (360 min) to FOUR_HOUR (240 min) for HTF analysis.

Kraken supported intervals: 1, 5, 15, 30, 60, **240**, 1440, 10080, 21600 min

## Test Plan
- [x] Verified FOUR_HOUR is supported by both Coinbase and Kraken
- [ ] Deploy and verify no runtime errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)