### PR TITLE
Fix confluence factor denominator: 6 -> 7 components (v1.28.10)

### DIFF
--- a/src/strategy/signal_scorer.py
+++ b/src/strategy/signal_scorer.py
@@ -735,7 +735,7 @@ class SignalScorer:
                 1 for key, score in breakdown.items()
                 if score != 0 and not key.startswith("_")
             )
-            confluence_factor = confluence_count / 6  # 6 components including trend_filter
+            confluence_factor = confluence_count / 7  # 7 components: rsi, macd, bollinger, ema, volume, trend_filter, htf_bias
 
             # Combine magnitude and confluence (equally weighted)
             magnitude_confidence = abs(total_score) / 100

--- a/src/version.py
+++ b/src/version.py
@@ -1,3 +1,3 @@
 """Version information for claude-trader."""
 
-__version__ = "1.28.9"
+__version__ = "1.28.10"


### PR DESCRIPTION
## Summary
Fixes #38 - Confluence factor calculation was dividing by 6 but there are now 7 score components.

## Problem
After adding `htf_bias` in the MTF PR, the confluence calculation became incorrect:
- **Before:** 6 components / 6 = max 100%
- **After MTF:** 7 components / 6 = max 117% (bug)

## Fix
Changed denominator from 6 to 7 with explicit component list:
```python
confluence_factor = confluence_count / 7  # rsi, macd, bollinger, ema, volume, trend_filter, htf_bias
```

## Components
1. rsi
2. macd
3. bollinger
4. ema
5. volume
6. trend_filter
7. htf_bias ← added in MTF PR

## Test Plan
- [x] Verified component count matches denominator
- [x] Confidence now correctly maxes at 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)