### PR TITLE
Add alerting for repeated signal history storage failures (v1.28.11)

### DIFF
--- a/src/version.py
+++ b/src/version.py
@@ -1,3 +1,3 @@
 """Version information for claude-trader."""
 
-__version__ = "1.28.10"
+__version__ = "1.28.11"


### PR DESCRIPTION
## Summary
- Track consecutive signal history storage failures
- Alert via Telegram after 10 consecutive failures
- Reset failure counter on successful storage

## Changes
- `src/daemon/runner.py`: Added `_signal_history_failures` counter and alerting logic
- `tests/test_trading_daemon.py`: Fixed pre-existing test failures (db.session mock), added new tests for alerting

## Test plan
- [x] Run `pytest tests/test_trading_daemon.py` - 48 tests pass
- [x] Verify `test_store_signal_history_alerts_after_repeated_failures` passes
- [x] Verify `test_store_signal_history_resets_failure_counter_on_success` passes

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)