### PR TITLE
Add AI_API_TIMEOUT config for API call timeouts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -227,6 +227,9 @@ AI_WEB_SEARCH_ENABLED=true
 # Max tokens for AI API responses (increase if seeing truncated JSON errors)
 AI_MAX_TOKENS=4000
 
+# API timeout in seconds (increase if seeing timeouts with slow models or web search)
+AI_API_TIMEOUT=120
+
 # Cache duration for research data (minutes) - avoids excessive API calls
 MARKET_RESEARCH_CACHE_MINUTES=15
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -427,6 +427,12 @@ class Settings(BaseSettings):
         le=16000,
         description="Maximum tokens for AI API responses (increase if seeing truncated JSON errors)"
     )
+    ai_api_timeout: int = Field(
+        default=120,
+        ge=30,
+        le=300,
+        description="Timeout in seconds for AI API calls (increase if seeing timeouts)"
+    )
     market_research_cache_minutes: int = Field(
         default=15,
         ge=5,

--- a/src/ai/trade_reviewer.py
+++ b/src/ai/trade_reviewer.py
@@ -492,6 +492,7 @@ class TradeReviewer:
         candle_interval: str = "ONE_HOUR",
         signal_threshold: int = 60,
         max_tokens: int = 4000,
+        api_timeout: int = 120,
     ):
         """
         Initialize multi-agent trade reviewer.
@@ -512,6 +513,7 @@ class TradeReviewer:
             market_research_cache_minutes: Cache duration for research data
             candle_interval: Candle timeframe for determining trading style
             max_tokens: Maximum tokens for AI API responses
+            api_timeout: Timeout in seconds for API calls
         """
         self.api_key = api_key
         self.db = db
@@ -528,6 +530,7 @@ class TradeReviewer:
         self.candle_interval = candle_interval
         self.signal_threshold = signal_threshold
         self.max_tokens = max_tokens
+        self.api_timeout = api_timeout
 
         # Set cache TTL for market research
         set_cache_ttl(market_research_cache_minutes)
@@ -1449,7 +1452,7 @@ Based on these three perspectives, provide the final market outlook."""
 
         logger.debug("api_request", model=model, tools_enabled=tools is not None)
 
-        async with httpx.AsyncClient(timeout=60.0) as client:
+        async with httpx.AsyncClient(timeout=float(self.api_timeout)) as client:
             # Initial request
             response = await client.post(
                 OPENROUTER_API_URL,

--- a/src/daemon/runner.py
+++ b/src/daemon/runner.py
@@ -184,6 +184,7 @@ class TradingDaemon:
                 candle_interval=settings.candle_interval,
                 signal_threshold=settings.signal_threshold,
                 max_tokens=settings.ai_max_tokens,
+                api_timeout=settings.ai_api_timeout,
             )
             logger.info(
                 "multi_agent_trade_reviewer_initialized",


### PR DESCRIPTION
## Summary
- Add `AI_API_TIMEOUT` config setting (default 120s, range 30-300s)
- Replace hardcoded 60s timeout in trade_reviewer.py
- Fixes timeouts when using slow models or web search

## Test plan
- [x] Tests pass
- [ ] Verify AI reviews complete without timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)