### PR TITLE
Show 'disabled' instead of 'neutral' for disabled HTF timeframes

### DIFF
--- a/src/strategy/signal_scorer.py
+++ b/src/strategy/signal_scorer.py
@@ -728,9 +728,9 @@ class SignalScorer:
             )
 
         breakdown["htf_bias"] = htf_adjustment
-        breakdown["_htf_trend"] = htf_bias or "neutral"
-        breakdown["_htf_daily"] = htf_daily or "neutral"
-        breakdown["_htf_4h"] = htf_4h or "neutral"
+        breakdown["_htf_trend"] = htf_bias if htf_bias is not None else "disabled"
+        breakdown["_htf_daily"] = htf_daily if htf_daily is not None else "disabled"
+        breakdown["_htf_4h"] = htf_4h if htf_4h is not None else "disabled"
 
         # Clamp score to -100 to +100
         total_score = max(-100, min(100, total_score))

--- a/src/version.py
+++ b/src/version.py
@@ -1,3 +1,3 @@
 """Version information for claude-trader."""
 
-__version__ = "1.31.0"
+__version__ = "1.31.1"

--- a/tests/test_signal_scorer.py
+++ b/tests/test_signal_scorer.py
@@ -1674,12 +1674,12 @@ class TestHTFBiasModifier:
         assert result.breakdown.get("_htf_4h") == "neutral"
 
     def test_htf_breakdown_defaults_when_none(self, mtf_scorer, bullish_signal_df):
-        """Test breakdown defaults to 'neutral' when HTF params are None."""
+        """Test breakdown defaults to 'disabled' when HTF params are None."""
         result = mtf_scorer.calculate_score(bullish_signal_df)
 
-        assert result.breakdown.get("_htf_trend") == "neutral"
-        assert result.breakdown.get("_htf_daily") == "neutral"
-        assert result.breakdown.get("_htf_4h") == "neutral"
+        assert result.breakdown.get("_htf_trend") == "disabled"
+        assert result.breakdown.get("_htf_daily") == "disabled"
+        assert result.breakdown.get("_htf_4h") == "disabled"
 
     def test_htf_custom_boost_values(self, bullish_signal_df):
         """Test custom aligned_boost and counter_penalty values work."""


### PR DESCRIPTION
## Summary
- When HTF timeframes (4h, daily, trend) are disabled (`None`), the breakdown now shows `'disabled'` instead of `'neutral'`
- This avoids confusion in logs where it appeared the timeframe was active and neutral when it was actually disabled

## Test plan
- [x] Updated test expectations for disabled HTF display
- [x] All 24 HTF-related tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)