### PR TITLE
Add OpenRouter app attribution headers (v1.31.2)

### DIFF
--- a/src/ai/trade_reviewer.py
+++ b/src/ai/trade_reviewer.py
@@ -1480,13 +1480,16 @@ Based on these three perspectives, provide the final market outlook."""
 
         async with httpx.AsyncClient(timeout=float(self.api_timeout)) as client:
             # Initial request
+            headers = {
+                "Authorization": f"Bearer {self.api_key}",
+                "Content-Type": "application/json",
+                "HTTP-Referer": "https://github.com/Byte-Ventures/claude-trader",
+                "X-Title": "Claude Trader",
+            }
+
             response = await client.post(
                 OPENROUTER_API_URL,
-                headers={
-                    "Authorization": f"Bearer {self.api_key}",
-                    "Content-Type": "application/json",
-                    "HTTP-Referer": "https://github.com/claude-trader",
-                },
+                headers=headers,
                 json=request_body,
             )
             response.raise_for_status()
@@ -1522,11 +1525,7 @@ Based on these three perspectives, provide the final market outlook."""
 
                 response = await client.post(
                     OPENROUTER_API_URL,
-                    headers={
-                        "Authorization": f"Bearer {self.api_key}",
-                        "Content-Type": "application/json",
-                        "HTTP-Referer": "https://github.com/claude-trader",
-                    },
+                    headers=headers,
                     json=request_body,
                 )
                 response.raise_for_status()

--- a/src/strategy/weight_profile_selector.py
+++ b/src/strategy/weight_profile_selector.py
@@ -270,6 +270,8 @@ class WeightProfileSelector:
                         headers={
                             "Authorization": f"Bearer {self.api_key}",
                             "Content-Type": "application/json",
+                            "HTTP-Referer": "https://github.com/Byte-Ventures/claude-trader",
+                            "X-Title": "Claude Trader",
                         },
                         json={
                             "model": self.config.model,

--- a/src/version.py
+++ b/src/version.py
@@ -1,3 +1,3 @@
 """Version information for claude-trader."""
 
-__version__ = "1.31.1"
+__version__ = "1.31.2"


### PR DESCRIPTION
## Summary
- Add `X-Title` and `HTTP-Referer` headers to all OpenRouter API requests for app attribution and analytics
- Fix missing headers in `weight_profile_selector.py` (was completely missing app headers)
- Show 'disabled' instead of 'neutral' for disabled HTF timeframes in notifications

## Test plan
- [ ] Verify OpenRouter requests include `X-Title: Claude Trader` header
- [ ] Verify OpenRouter requests include `HTTP-Referer: https://github.com/Byte-Ventures/claude-trader` header
- [ ] Check app appears in OpenRouter analytics after some API usage
- [ ] Verify HTF display shows "disabled" correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)