### PR TITLE
docs: update workflow to use reset instead of rebase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,19 +139,19 @@ When creating new configuration parameters:
 ### Workflow
 
 1. Create feature/fix branch from `develop`
-2. Make changes and commit with version bump
+2. Make changes and commit using conventional commit format
 3. Push and create PR to `develop`
 4. After review, merge to `develop`
 5. When ready for release, create PR from `develop` to `main`
-6. **After every PR merge to `main`**, rebase `develop` onto `main`:
+6. **After every PR merge to `main`**, reset `develop` to `main`:
    ```bash
    git checkout develop
    git fetch origin main
-   git rebase origin/main
+   git reset --hard origin/main
    git push --force-with-lease origin develop
    ```
 
-**Why rebase instead of merge?** Merging main back into develop creates merge commits that pollute the commit history. This causes PRs to show dozens of "commits" even when only a few files changed. Rebasing keeps the history linear and PRs clean.
+**Why reset instead of rebase?** PRs to main are squash-merged (cleaner main history). Rebasing would try to replay the original commits that are already in main (as squash commits), causing conflicts. Reset is safe because all work is already merged.
 
 ### Creating PRs to Main
 


### PR DESCRIPTION
## Summary

Updates CLAUDE.md workflow documentation to use `git reset --hard` instead of `git rebase` after squash merging PRs to main.

## Why

PRs to main are squash-merged, which creates new commits. Rebasing develop onto main tries to replay the original commits that already exist (in squash form), causing conflicts. Reset is the correct approach.

## Changes

- Step 6: `git rebase origin/main` → `git reset --hard origin/main`
- Updated explanation to clarify why reset is needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)