### PR TITLE
chore: add CHANGELOG.md for semantic-release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+This file is automatically updated by semantic-release.


### PR DESCRIPTION
semantic-release requires CHANGELOG.md to exist before it can update it.