### PR TITLE
fix: manually commit version changes after semantic-release

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -75,8 +75,12 @@ jobs:
           VERSION="${{ steps.version.outputs.next }}"
           BRANCH="release/v${VERSION}"
 
-          # Run semantic-release on main first (only works on configured branches)
+          # Run semantic-release to update version files (doesn't commit with these flags)
           semantic-release version --no-push --no-tag --no-vcs-release
+
+          # Commit the version changes manually
+          git add -A
+          git commit -m "chore(release): ${VERSION}"
 
           # Create release branch from the committed changes
           git checkout -b "$BRANCH"


### PR DESCRIPTION
semantic-release with --no-push --no-tag --no-vcs-release updates files but doesn't commit. Added manual git add/commit step.