### PR TITLE
fix: add --no-commit flag to prevent commit_sha error

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -75,8 +75,8 @@ jobs:
           VERSION="${{ steps.version.outputs.next }}"
           BRANCH="release/v${VERSION}"
 
-          # Run semantic-release to update version files (doesn't commit with these flags)
-          semantic-release version --no-push --no-tag --no-vcs-release
+          # Run semantic-release to update version files only (--no-commit prevents internal commit attempt)
+          semantic-release version --no-commit --no-tag --no-vcs-release
 
           # Commit the version changes manually
           git add -A


### PR DESCRIPTION
The `--no-commit` flag tells semantic-release to only update files without attempting an internal commit. This prevents the 'commit_sha not set' error.

Per [python-semantic-release docs](https://python-semantic-release.readthedocs.io/en/latest/api/commands.html), `--no-push` is implied by `--no-commit`.