### PR TITLE
fix: use structured_output for postmortem workflow

### DIFF
--- a/.github/workflows/claude-postmortem-review.yml
+++ b/.github/workflows/claude-postmortem-review.yml
@@ -84,16 +84,41 @@ jobs:
           claude_args: >-
             --max-turns 10
             --allowed-tools "Read,Glob,Grep"
+            --json-schema '{"type":"object","properties":{"has_valid_fixes":{"type":"boolean"},"fixes":{"type":"array"},"issue_title":{"type":"string"},"issue_body":{"type":"string"},"reason":{"type":"string"}},"required":["has_valid_fixes"]}'
 
       - name: Parse analysis result
         id: parse
         uses: actions/github-script@v7
         with:
           script: |
-            const output = `${{ steps.analyze.outputs.response }}`;
+            const fs = require('fs');
+
+            // Try structured_output first, fall back to execution_file
+            let output = `${{ steps.analyze.outputs.structured_output }}`;
+
+            if (!output || output.trim() === '') {
+              // Read from execution file
+              const execFile = `${{ steps.analyze.outputs.execution_file }}`;
+              if (execFile && fs.existsSync(execFile)) {
+                const execData = JSON.parse(fs.readFileSync(execFile, 'utf8'));
+                // Find the last assistant message with text content
+                for (let i = execData.length - 1; i >= 0; i--) {
+                  const msg = execData[i];
+                  if (msg.type === 'assistant' && msg.message?.content) {
+                    for (const block of msg.message.content) {
+                      if (block.type === 'text') {
+                        output = block.text;
+                        break;
+                      }
+                    }
+                    if (output) break;
+                  }
+                }
+              }
+            }
 
             // Extract JSON from response
-            const jsonMatch = output.match(/\{[\s\S]*\}/);
+            const jsonMatch = output ? output.match(/\{[\s\S]*\}/) : null;
             if (!jsonMatch) {
               core.setOutput('has_fixes', 'false');
               core.setOutput('reason', 'Could not parse analysis output');


### PR DESCRIPTION
## Summary

The `claude-code-action` doesn't have a `response` output - it was returning empty.

Fix: Use `structured_output` with `--json-schema` to get Claude's validated JSON response.

## Test plan

- [ ] Trigger postmortem workflow and verify issue is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)