### PR TITLE
fix: trigger auto-fix workflow on issue creation with labels

### DIFF
--- a/.github/workflows/claude-auto-fix.yml
+++ b/.github/workflows/claude-auto-fix.yml
@@ -2,11 +2,13 @@ name: Claude Auto-Fix Issues
 
 on:
   issues:
-    types: [labeled]
+    types: [labeled, opened]
 
 jobs:
   auto-fix:
-    if: github.event.label.name == 'auto-fix'
+    if: |
+      (github.event.action == 'labeled' && github.event.label.name == 'auto-fix') ||
+      (github.event.action == 'opened' && contains(github.event.issue.labels.*.name, 'auto-fix'))
     runs-on: ubuntu-latest
     timeout-minutes: 30
 


### PR DESCRIPTION
## Summary

The `labeled` event only fires when a label is **added** to an existing issue, not when an issue is **created with** labels already attached.

The postmortem-review workflow creates issues with labels pre-set, so the auto-fix workflow never triggered.

## Changes

- Add `opened` to trigger types
- Check for `auto-fix` label in both `labeled` and `opened` events

## Test plan

- [ ] Create issue #103 again (or re-add auto-fix label) to trigger workflow
- [ ] Verify auto-fix workflow starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)