### PR TITLE
fix: add contents:write permission for repository_dispatch

### DIFF
--- a/.github/workflows/claude-postmortem-review.yml
+++ b/.github/workflows/claude-postmortem-review.yml
@@ -14,7 +14,7 @@ jobs:
       cancel-in-progress: false
 
     permissions:
-      contents: read
+      contents: write  # Required for repository_dispatch
       discussions: read
       issues: write
       id-token: write


### PR DESCRIPTION
## Summary
- Fix permission error when postmortem-review tries to dispatch auto-fix workflow
- `repository_dispatch` requires `contents: write` permission

## Problem
```
Failed to dispatch auto-fix for issue #118: Resource not accessible by integration
```

## Solution
Changed `contents: read` to `contents: write` in postmortem-review workflow.

## Test plan
- [ ] Manually trigger auto-fix on issues #118-121 (remove/re-add `auto-fix` label)
- [ ] Or create new postmortem discussion to test full flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)