### PR TITLE
feat(config): validate OpenRouter API key on startup

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -747,6 +747,8 @@ class Settings(BaseSettings):
                     headers={
                         "Authorization": f"Bearer {api_key}",
                         "Content-Type": "application/json",
+                        "HTTP-Referer": "https://github.com/Byte-Ventures/claude-trader",
+                        "X-Title": "Claude Trader",
                     },
                     json={
                         "model": "openai/gpt-3.5-turbo",


### PR DESCRIPTION
## Summary

Add startup validation for AI review configuration to fail fast when misconfigured.

## Changes

- Add `validate_ai_review_config()` model validator to `config/settings.py`
- Require `OPENROUTER_API_KEY` when `AI_REVIEW_ENABLED=true`
- Test API key validity with minimal OpenRouter API request on startup
- Provide clear error messages for missing or invalid API keys

## Motivation

Previously, the bot would start successfully with `AI_REVIEW_ENABLED=true` but no API key configured, only to fail later during trading operations when attempting to use AI review features. This commit ensures configuration is validated immediately on startup, preventing runtime failures in production.

## Test Plan

- [x] Tested with `AI_REVIEW_ENABLED=true` and no API key - correctly rejects startup
- [x] Tested with `AI_REVIEW_ENABLED=true` and invalid API key - correctly rejects startup  
- [x] Tested with `AI_REVIEW_ENABLED=true` and valid API key - startup succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)