### PR TITLE
fix(daemon): use hard position limit for room check

### DIFF
--- a/src/daemon/runner.py
+++ b/src/daemon/runner.py
@@ -1181,7 +1181,8 @@ class TradingDaemon:
         # Determine which trade directions are possible
         min_quote = Decimal(str(self.position_sizer.config.min_trade_quote))
         min_base = Decimal(str(self.position_sizer.config.min_trade_base))
-        max_position_pct = self.position_sizer.config.max_position_percent
+        # Use validator's hard limit (MAX_POSITION_PERCENT), not position sizer's soft target
+        max_position_pct = self.validator.config.max_position_percent
 
         # Check if there's meaningful room to buy (at least 1% of portfolio or min_trade_quote)
         # This prevents running AI review when position is nearly at limit


### PR DESCRIPTION
## Summary

Fix incorrect position limit check that was blocking buys when position exceeded the soft target, even though room remained before the hard safety limit.

## Problem

The "room check" in `runner.py:1184` was using `POSITION_SIZE_PERCENT` (soft target for trade sizing) instead of `MAX_POSITION_PERCENT` (hard safety limit) when determining if there's room to buy.

**Example scenario:**
- `POSITION_SIZE_PERCENT=20%` (soft target - each trade targets 20% of portfolio)
- `MAX_POSITION_PERCENT=90%` (hard limit - validator rejects trades above 90%)
- Current position: 85.6%

**Incorrect behavior:**
```
available_room = 20% - 85.6% = -65.55%
Result: Buy blocked (no room)
```

**Correct behavior:**
```
available_room = 90% - 85.6% = 4.4%
Result: Buy allowed (4.4% room remaining)
```

## Solution

Changed line 1185 to use the validator's hard limit:
```python
# Before
max_position_pct = self.position_sizer.config.max_position_percent  # 20%

# After
max_position_pct = self.validator.config.max_position_percent  # 90%
```

## Impact

- Allows position to grow beyond the soft target through multiple trades
- Still respects the hard safety limit enforced by the validator
- Fixes false "insufficient room" blocks when position is between soft and hard limits

## Test Plan

- [x] Verified with position at 85.6%, POSITION_SIZE_PERCENT=20%, MAX_POSITION_PERCENT=90%
- [x] Room check now correctly shows 4.4% available instead of blocking

🤖 Generated with [Claude Code](https://claude.com/claude-code)