### PR TITLE
fix(ci): use direct merge instead of auto-merge for release PRs

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -154,7 +154,14 @@ jobs:
 
           echo "Created PR: $PR_URL"
 
+          # Wait for GitHub to process the PR
+          sleep 5
+
           # Merge the release PR directly
-          gh pr merge "$BRANCH" --squash --delete-branch
+          if ! gh pr merge "$BRANCH" --squash --delete-branch; then
+            echo "::error::Failed to merge release PR"
+            echo "::notice::Manual merge required: $PR_URL"
+            exit 1
+          fi
 
           echo "::notice::Release PR merged: $PR_URL"


### PR DESCRIPTION
## Summary
- Replace `gh pr merge --auto --squash` with `gh pr merge --squash --delete-branch`

## Problem
Auto-merge was failing with `Pull request is in clean status` because no required status checks are configured on the main branch.

## Solution
Use direct merge instead of auto-merge. The workflow already has the required permissions (`contents: write`, `pull-requests: write`).

## Test plan
- [ ] Merge this PR to main
- [ ] Verify semantic-release workflow creates and merges the release PR automatically