### PR TITLE
feat(config): make SENTIMENT_TREND_MODIFIERS table configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -410,6 +410,30 @@ BLOCK_TRADES_EXTREME_CONDITIONS=true
 # See "Stop Loss / Trailing Stop" section above for STOP_LOSS_ATR_MULTIPLIER_EXTREME
 
 # ==============================================================================
+# SENTIMENT-TREND MODIFIERS (Advanced - Optional)
+# ==============================================================================
+
+# Custom sentiment-trend interaction modifiers for regime adaptation
+# When unset (default), uses hardcoded values from src/strategy/regime.py
+# Format: JSON object with 30 keys (5 sentiments × 3 trends × 2 signals)
+# Example keys: extreme_fear_bearish_buy, greed_bullish_sell, neutral_neutral_buy, etc.
+# Each key maps to: {"threshold_mult": 0.0-2.0, "position_mult": 0.5-1.5}
+#
+# threshold_mult: Multiplier for sentiment threshold adjustment
+#   - 0.0 = ignore sentiment adjustment entirely
+#   - 1.0 = apply full sentiment adjustment
+#   - >1.0 = amplify sentiment adjustment
+#
+# position_mult: Additional position size multiplier (compounds with base)
+#
+# Only set this if you understand the regime system and want to tune it.
+# See src/strategy/regime.py SENTIMENT_TREND_MODIFIERS for the full default table.
+#
+# Example (simplified - all 30 keys required):
+# SENTIMENT_TREND_MODIFIERS={"extreme_fear_bullish_buy":{"threshold_mult":1.2,"position_mult":1.15},"extreme_fear_bearish_buy":{"threshold_mult":0.0,"position_mult":0.7},...}
+# SENTIMENT_TREND_MODIFIERS=
+
+# ==============================================================================
 # CRAMER MODE (Paper Trading Only)
 # ==============================================================================
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -699,6 +699,12 @@ class Settings(BaseSettings):
         description="Block new positions when both sentiment and volatility are extreme"
     )
 
+    # Sentiment-Trend Modifiers for Market Regime Adaptation
+    sentiment_trend_modifiers: Optional[dict] = Field(
+        default=None,
+        description="Custom sentiment-trend interaction modifiers. If None, uses hardcoded defaults in regime.py. Format: JSON object with keys like 'extreme_fear_bearish_buy' containing threshold_mult and position_mult values."
+    )
+
     # Cramer Mode Mode (paper trading only)
     enable_cramer_mode: bool = Field(
         default=False,
@@ -873,6 +879,85 @@ class Settings(BaseSettings):
                 f"(current gap: {gap}). Narrow gaps create false crash/pump signals."
             )
         return self
+
+    @field_validator("sentiment_trend_modifiers")
+    @classmethod
+    def validate_sentiment_trend_modifiers(cls, v: Optional[dict]) -> Optional[dict]:
+        """Validate sentiment-trend modifiers configuration."""
+        if v is None:
+            return None
+
+        # Expected keys (30 combinations: 5 sentiments × 3 trends × 2 signals)
+        sentiments = ["extreme_fear", "fear", "neutral", "greed", "extreme_greed"]
+        trends = ["bullish", "bearish", "neutral"]
+        signals = ["buy", "sell"]
+
+        expected_keys = [
+            f"{sentiment}_{trend}_{signal}"
+            for sentiment in sentiments
+            for trend in trends
+            for signal in signals
+        ]
+
+        # Validate all required keys present
+        missing_keys = set(expected_keys) - set(v.keys())
+        if missing_keys:
+            raise ValueError(
+                f"sentiment_trend_modifiers missing required keys: {sorted(missing_keys)}. "
+                f"All 30 combinations must be present."
+            )
+
+        # Validate no extra keys present
+        extra_keys = set(v.keys()) - set(expected_keys)
+        if extra_keys:
+            raise ValueError(
+                f"sentiment_trend_modifiers has unexpected keys: {sorted(extra_keys)}. "
+                f"Remove any extra keys."
+            )
+
+        # Validate each entry has correct structure and valid ranges
+        for key, modifiers in v.items():
+            if key not in expected_keys:
+                raise ValueError(
+                    f"sentiment_trend_modifiers has invalid key: {key}. "
+                    f"Valid keys are combinations like 'extreme_fear_bearish_buy'."
+                )
+
+            if not isinstance(modifiers, dict):
+                raise ValueError(
+                    f"sentiment_trend_modifiers[{key}] must be a dict, got {type(modifiers)}"
+                )
+
+            if "threshold_mult" not in modifiers or "position_mult" not in modifiers:
+                raise ValueError(
+                    f"sentiment_trend_modifiers[{key}] must have 'threshold_mult' and 'position_mult' keys"
+                )
+
+            threshold_mult = modifiers["threshold_mult"]
+            position_mult = modifiers["position_mult"]
+
+            # Validate types
+            if not isinstance(threshold_mult, (int, float)):
+                raise ValueError(
+                    f"sentiment_trend_modifiers[{key}].threshold_mult must be numeric, got {type(threshold_mult).__name__}"
+                )
+            if not isinstance(position_mult, (int, float)):
+                raise ValueError(
+                    f"sentiment_trend_modifiers[{key}].position_mult must be numeric, got {type(position_mult).__name__}"
+                )
+
+            # Validate ranges
+            if not (0.0 <= threshold_mult <= 2.0):
+                raise ValueError(
+                    f"sentiment_trend_modifiers[{key}].threshold_mult must be 0.0-2.0, got {threshold_mult}"
+                )
+
+            if not (0.5 <= position_mult <= 1.5):
+                raise ValueError(
+                    f"sentiment_trend_modifiers[{key}].position_mult must be 0.5-1.5, got {position_mult}"
+                )
+
+        return v
 
     @model_validator(mode="before")
     @classmethod

--- a/src/daemon/runner.py
+++ b/src/daemon/runner.py
@@ -404,7 +404,8 @@ class TradingDaemon:
                 volatility_enabled=settings.regime_volatility_enabled,
                 trend_enabled=settings.regime_trend_enabled,
                 adjustment_scale=settings.regime_adjustment_scale,
-            )
+            ),
+            custom_modifiers=settings.sentiment_trend_modifiers,
         )
         if settings.regime_adaptation_enabled:
             # Restore last regime from database

--- a/tests/test_regime.py
+++ b/tests/test_regime.py
@@ -1186,3 +1186,236 @@ class TestTrendAwareSentimentModifiers:
         # Bullish trend should amplify the greed effect for sells
         assert result_bullish_trend.components["sentiment"]["threshold_adj"] >= \
                result_neutral_trend.components["sentiment"]["threshold_adj"]
+
+
+# ============================================================================
+# Custom Modifiers Tests
+# ============================================================================
+
+class TestCustomModifiers:
+    """Test custom sentiment-trend modifiers configuration."""
+
+    def test_custom_modifiers_override_defaults(self):
+        """Test custom modifiers override hardcoded defaults."""
+        # Create custom modifiers with all 30 required entries (5 sentiments × 3 trends × 2 signals)
+        custom = {
+            "extreme_fear_bearish_buy": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "extreme_fear_bearish_sell": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "extreme_fear_bullish_buy": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "extreme_fear_bullish_sell": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "extreme_fear_neutral_buy": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "extreme_fear_neutral_sell": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "fear_bearish_buy": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "fear_bearish_sell": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "fear_bullish_buy": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "fear_bullish_sell": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "fear_neutral_buy": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "fear_neutral_sell": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "neutral_bearish_buy": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "neutral_bearish_sell": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "neutral_bullish_buy": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "neutral_bullish_sell": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "neutral_neutral_buy": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "neutral_neutral_sell": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "greed_bearish_buy": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "greed_bearish_sell": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "greed_bullish_buy": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "greed_bullish_sell": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "greed_neutral_buy": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "greed_neutral_sell": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "extreme_greed_bearish_buy": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "extreme_greed_bearish_sell": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "extreme_greed_bullish_buy": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "extreme_greed_bullish_sell": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "extreme_greed_neutral_buy": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "extreme_greed_neutral_sell": {"threshold_mult": 1.0, "position_mult": 1.0},
+        }
+
+        regime = MarketRegime(custom_modifiers=custom)
+
+        # Verify the custom value is used (all should be 1.0, 1.0)
+        assert regime.sentiment_trend_modifiers[("extreme_fear", "bearish", "buy")] == {
+            "threshold_mult": 1.0, "position_mult": 1.0
+        }
+        # Verify defaults would have been different
+        assert MarketRegime.SENTIMENT_TREND_MODIFIERS[("extreme_fear", "bearish", "buy")]["threshold_mult"] == 0.0
+
+    def test_custom_modifiers_actually_applied(self):
+        """Test custom modifiers are actually used in calculations."""
+        # Create custom modifiers that neutralize extreme_fear in bearish trends
+        custom = {
+            "extreme_fear_bearish_buy": {"threshold_mult": 1.0, "position_mult": 1.0},  # Full discount applied
+            "extreme_fear_bearish_sell": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "extreme_fear_bullish_buy": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "extreme_fear_bullish_sell": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "extreme_fear_neutral_buy": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "extreme_fear_neutral_sell": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "fear_bearish_buy": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "fear_bearish_sell": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "fear_bullish_buy": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "fear_bullish_sell": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "fear_neutral_buy": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "fear_neutral_sell": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "neutral_bearish_buy": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "neutral_bearish_sell": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "neutral_bullish_buy": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "neutral_bullish_sell": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "neutral_neutral_buy": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "neutral_neutral_sell": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "greed_bearish_buy": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "greed_bearish_sell": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "greed_bullish_buy": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "greed_bullish_sell": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "greed_neutral_buy": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "greed_neutral_sell": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "extreme_greed_bearish_buy": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "extreme_greed_bearish_sell": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "extreme_greed_bullish_buy": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "extreme_greed_bullish_sell": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "extreme_greed_neutral_buy": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "extreme_greed_neutral_sell": {"threshold_mult": 1.0, "position_mult": 1.0},
+        }
+
+        regime = MarketRegime(custom_modifiers=custom)
+
+        # Calculate with extreme fear in bearish trend
+        result = regime.calculate(
+            sentiment=FearGreedResult(value=15, classification="Extreme Fear", timestamp=None),
+            volatility="normal",
+            trend="bearish",
+            signal_action="buy",
+        )
+
+        # With threshold_mult=1.0, the full -10 discount should apply
+        assert result.components["sentiment"]["threshold_adj"] == -10
+
+        # Compare to default regime which should nullify the discount
+        default_regime = MarketRegime()
+        default_result = default_regime.calculate(
+            sentiment=FearGreedResult(value=15, classification="Extreme Fear", timestamp=None),
+            volatility="normal",
+            trend="bearish",
+            signal_action="buy",
+        )
+        # Default should nullify (threshold_mult=0.0)
+        assert default_result.components["sentiment"]["threshold_adj"] == 0
+
+    def test_incomplete_custom_modifiers_falls_back(self):
+        """Test incomplete custom modifiers fall back to defaults."""
+        # Only provide 5 entries instead of 30
+        incomplete = {
+            "extreme_fear_bearish_buy": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "extreme_fear_bearish_sell": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "extreme_fear_bullish_buy": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "extreme_fear_bullish_sell": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "extreme_fear_neutral_buy": {"threshold_mult": 1.0, "position_mult": 1.0},
+        }
+
+        regime = MarketRegime(custom_modifiers=incomplete)
+
+        # Should fall back to defaults
+        assert regime.sentiment_trend_modifiers == MarketRegime.SENTIMENT_TREND_MODIFIERS
+
+    def test_invalid_key_format_skipped(self):
+        """Test invalid key formats are skipped during parsing."""
+        # Mix valid and invalid keys
+        mixed = {
+            # Valid
+            "extreme_fear_bearish_buy": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "extreme_fear_bearish_sell": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "extreme_fear_bullish_buy": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "extreme_fear_bullish_sell": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "extreme_fear_neutral_buy": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "extreme_fear_neutral_sell": {"threshold_mult": 1.0, "position_mult": 1.0},
+            # Invalid format
+            "invalid_key": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "another_bad_one": {"threshold_mult": 1.0, "position_mult": 1.0},
+            # More valid
+            "fear_bearish_buy": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "fear_bearish_sell": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "fear_bullish_buy": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "fear_bullish_sell": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "fear_neutral_buy": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "fear_neutral_sell": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "neutral_bearish_buy": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "neutral_bearish_sell": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "neutral_bullish_buy": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "neutral_bullish_sell": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "neutral_neutral_buy": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "neutral_neutral_sell": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "greed_bearish_buy": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "greed_bearish_sell": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "greed_bullish_buy": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "greed_bullish_sell": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "greed_neutral_buy": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "greed_neutral_sell": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "extreme_greed_bearish_buy": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "extreme_greed_bearish_sell": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "extreme_greed_bullish_buy": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "extreme_greed_bullish_sell": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "extreme_greed_neutral_buy": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "extreme_greed_neutral_sell": {"threshold_mult": 1.0, "position_mult": 1.0},
+        }
+
+        regime = MarketRegime(custom_modifiers=mixed)
+
+        # Invalid keys should be skipped, but we only have 30 valid ones so it should work
+        assert len(regime.sentiment_trend_modifiers) == 30
+
+    def test_string_parsing_handles_underscores_in_sentiment(self):
+        """Test robust parsing handles sentiment names with underscores."""
+        # Use a sentiment name with underscores
+        custom = {
+            "extreme_fear_bearish_buy": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "extreme_fear_bearish_sell": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "extreme_fear_bullish_buy": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "extreme_fear_bullish_sell": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "extreme_fear_neutral_buy": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "extreme_fear_neutral_sell": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "fear_bearish_buy": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "fear_bearish_sell": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "fear_bullish_buy": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "fear_bullish_sell": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "fear_neutral_buy": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "fear_neutral_sell": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "neutral_bearish_buy": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "neutral_bearish_sell": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "neutral_bullish_buy": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "neutral_bullish_sell": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "neutral_neutral_buy": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "neutral_neutral_sell": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "greed_bearish_buy": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "greed_bearish_sell": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "greed_bullish_buy": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "greed_bullish_sell": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "greed_neutral_buy": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "greed_neutral_sell": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "extreme_greed_bearish_buy": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "extreme_greed_bearish_sell": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "extreme_greed_bullish_buy": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "extreme_greed_bullish_sell": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "extreme_greed_neutral_buy": {"threshold_mult": 1.0, "position_mult": 1.0},
+            "extreme_greed_neutral_sell": {"threshold_mult": 1.0, "position_mult": 1.0},
+        }
+
+        regime = MarketRegime(custom_modifiers=custom)
+
+        # Should correctly parse extreme_fear as sentiment
+        assert ("extreme_fear", "bearish", "buy") in regime.sentiment_trend_modifiers
+        assert regime.sentiment_trend_modifiers[("extreme_fear", "bearish", "buy")] == {
+            "threshold_mult": 1.0, "position_mult": 1.0
+        }
+
+    def test_no_custom_modifiers_uses_defaults(self):
+        """Test MarketRegime without custom_modifiers uses defaults."""
+        regime = MarketRegime()
+
+        # Should use hardcoded defaults
+        assert regime.sentiment_trend_modifiers == MarketRegime.SENTIMENT_TREND_MODIFIERS
+
+    def test_none_custom_modifiers_uses_defaults(self):
+        """Test MarketRegime with custom_modifiers=None uses defaults."""
+        regime = MarketRegime(custom_modifiers=None)
+
+        # Should use hardcoded defaults
+        assert regime.sentiment_trend_modifiers == MarketRegime.SENTIMENT_TREND_MODIFIERS

--- a/tests/test_trading_daemon.py
+++ b/tests/test_trading_daemon.py
@@ -107,6 +107,7 @@ def mock_settings():
     settings.regime_trend_enabled = False
     settings.regime_adjustment_scale = 0.5
     settings.regime_flap_protection = True
+    settings.sentiment_trend_modifiers = None  # Use default hardcoded modifiers
 
     # AI Weight Profile config
     settings.ai_weight_profile_enabled = False


### PR DESCRIPTION
## Summary

- Add configurable sentiment-trend modifiers via `SENTIMENT_TREND_MODIFIERS` env var
- Add comprehensive validation in settings.py (30 required keys, value ranges)
- Add missing neutral sentiment entries to complete the 5×3×2 matrix
- Fall back to hardcoded defaults when config is missing or invalid

Closes #68

## Test plan

- [x] All 806 unit tests pass
- [x] New `TestCustomModifiers` class covers custom modifier functionality
- [x] Settings validation tested for missing keys, extra keys, out-of-range values
- [x] Verified env var JSON parsing works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)