### PR TITLE
feat(ai): rate limit AI judge reviews after rejection until next candle

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -299,6 +299,11 @@ INTERESTING_HOLD_MARGIN=15 # Score margin (45-75 with threshold 60)
 # Debug mode - reviews ALL decisions, not just trades/interesting holds
 AI_REVIEW_ALL=false
 
+# AI Review Rejection Cooldown
+# Skip AI reviews until next candle after judge rejects trade (SKIP/REDUCE veto)
+# Prevents spamming the judge with the same signal repeatedly
+AI_REVIEW_REJECTION_COOLDOWN=true
+
 # AI Failure Mode - what happens when AI review fails/times out
 # open = proceed with trade (fail-open)
 # safe = skip trade (fail-safe)

--- a/config/settings.py
+++ b/config/settings.py
@@ -538,6 +538,10 @@ class Settings(BaseSettings):
         default=False,
         description="Review ALL decisions with AI (for debugging/testing)"
     )
+    ai_review_rejection_cooldown: bool = Field(
+        default=True,
+        description="Skip AI reviews until next candle after SKIP/REDUCE veto"
+    )
     ai_failure_mode: AIFailureMode = Field(
         default=AIFailureMode.OPEN,
         description="DEPRECATED: Use ai_failure_mode_buy/sell instead. Fallback if per-action not set."


### PR DESCRIPTION
## Summary

- After a SKIP or REDUCE veto from the AI judge, skip further reviews until a new candle period begins or signal direction changes
- Reduces unnecessary API costs by not repeatedly requesting reviews for rejected signals
- Respects the judge's decision for the current market conditions

Closes #224

## Changes

| File | Description |
|------|-------------|
| `config/settings.py` | Added `ai_review_rejection_cooldown` setting (default: `true`) |
| `.env.example` | Documented new setting |
| `src/daemon/runner.py` | Added cooldown logic with candle period calculation |
| `tests/test_trading_daemon.py` | Added 7 unit tests for veto cooldown |

## Configuration

```bash
# Skip AI reviews until next candle after judge rejects trade (SKIP/REDUCE veto)
AI_REVIEW_REJECTION_COOLDOWN=true  # default
```

## Behavior

Cooldown resets when:
1. **New candle period begins** (based on `CANDLE_INTERVAL` setting)
2. **Signal direction changes** (BUY → SELL or vice versa)

## Test plan

- [x] Unit tests for `_get_candle_start()` method
- [x] Unit tests for `_should_skip_review_after_veto()` method
- [x] Test cooldown activates after SKIP veto
- [x] Test cooldown activates after REDUCE veto
- [x] Test cooldown resets on new candle
- [x] Test cooldown resets on direction change
- [x] Test disabled when setting is False
- [x] Full test suite passes (835 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)