### PR TITLE
Release: AI review veto cooldown

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -299,6 +299,11 @@ INTERESTING_HOLD_MARGIN=15 # Score margin (45-75 with threshold 60)
 # Debug mode - reviews ALL decisions, not just trades/interesting holds
 AI_REVIEW_ALL=false
 
+# AI Review Rejection Cooldown
+# Skip AI reviews until next candle after judge rejects trade (SKIP/REDUCE veto)
+# Prevents spamming the judge with the same signal repeatedly
+AI_REVIEW_REJECTION_COOLDOWN=true
+
 # AI Failure Mode - what happens when AI review fails/times out
 # open = proceed with trade (fail-open)
 # safe = skip trade (fail-safe)

--- a/config/settings.py
+++ b/config/settings.py
@@ -538,6 +538,10 @@ class Settings(BaseSettings):
         default=False,
         description="Review ALL decisions with AI (for debugging/testing)"
     )
+    ai_review_rejection_cooldown: bool = Field(
+        default=True,
+        description="Skip AI reviews until next candle after SKIP/REDUCE veto"
+    )
     ai_failure_mode: AIFailureMode = Field(
         default=AIFailureMode.OPEN,
         description="DEPRECATED: Use ai_failure_mode_buy/sell instead. Fallback if per-action not set."


### PR DESCRIPTION
## Summary

- Rate limit AI judge reviews after rejection until next candle period

## Changes

### feat(ai): rate limit AI judge reviews after rejection (#228)
After a SKIP or REDUCE veto from the AI judge, skip further reviews until:
- A new candle period begins, OR
- Signal direction changes (BUY → SELL or vice versa)

**New configuration:** `AI_REVIEW_REJECTION_COOLDOWN=true` (default)

Closes #224

## Test plan

- [x] 7 new unit tests for veto cooldown
- [x] Full test suite passes (835 tests)
- [ ] Deploy to server and monitor logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)