### PR TITLE
fix(ci): add workflows write permission to claude-auto-fix

### DIFF
--- a/.github/workflows/claude-auto-fix.yml
+++ b/.github/workflows/claude-auto-fix.yml
@@ -23,6 +23,7 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
+      workflows: write
       id-token: write
 
     steps:


### PR DESCRIPTION
## Summary

Add `workflows: write` permission to the claude-auto-fix workflow to allow PR creation.

## Problem

The auto-fix workflow failed to create PR for issue #259:
https://github.com/Byte-Ventures/claude-trader/actions/runs/20407955771

Error: Permission denied when creating PR that would trigger other workflows.

## Solution

Add missing permission:

```yaml
permissions:
  contents: write
  pull-requests: write
  issues: write
  workflows: write  # Added
  id-token: write
```

## Test Plan

- Re-run auto-fix on issue #259 after this is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)