### PR TITLE
feat(ci): post clear message when no review changes needed

### DIFF
--- a/.github/workflows/claude-address-review.yml
+++ b/.github/workflows/claude-address-review.yml
@@ -117,6 +117,10 @@ jobs:
           git config user.name "claude[bot]"
           git config user.email "noreply@anthropic.com"
 
+      - name: Get current SHA
+        id: before
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Address review comments with Claude
         uses: anthropics/claude-code-action@v1
         with:
@@ -151,15 +155,30 @@ jobs:
             --max-turns 50
             --allowed-tools "Read,Write,Edit,Glob,Grep,Bash(git:*),Bash(python3:*),Bash(pytest:*),Bash(pip:*)"
 
+      - name: Get after SHA
+        id: after
+        if: always()
+        run: echo "sha=$(git rev-parse HEAD 2>/dev/null || echo 'unknown')" >> "$GITHUB_OUTPUT"
+
       - name: Comment on PR
         if: always()
         uses: actions/github-script@v7
         with:
           script: |
             const success = '${{ job.status }}' === 'success';
-            const body = success
-              ? `Review feedback addressed. Please re-review.\n\n[Workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})`
-              : `Failed to address review feedback.\n\n[Check logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})`;
+            const beforeSha = '${{ steps.before.outputs.sha }}';
+            const afterSha = '${{ steps.after.outputs.sha }}';
+            const noChanges = beforeSha === afterSha;
+            const workflowUrl = '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}';
+
+            let body;
+            if (!success) {
+              body = `Failed to address review feedback.\n\n[Check logs](${workflowUrl})`;
+            } else if (noChanges) {
+              body = `✅ **No changes required**\n\nAll review feedback has been addressed or no actionable items were found.\n\n[Workflow run](${workflowUrl})`;
+            } else {
+              body = `Review feedback addressed. Please re-review.\n\n[Workflow run](${workflowUrl})`;
+            }
 
             await github.rest.issues.createComment({
               owner: context.repo.owner,


### PR DESCRIPTION
## Summary

When Claude Address Review determines no changes are needed, it now posts a distinct message instead of the generic "Review feedback addressed" message.

**Before**: Always shows "Review feedback addressed" even when no changes were made
**After**: Shows one of three messages:
- ✅ **No changes required** - when SHA unchanged (all feedback already addressed)
- Review feedback addressed - when commits were made
- Failed to address review feedback - when job failed

## Implementation

- Added `Get current SHA` step before Claude runs to capture the starting point
- Added `Get after SHA` step after Claude runs
- Updated `Comment on PR` step to compare SHAs and post appropriate message

## Test plan

- [ ] Trigger workflow on a PR where all issues are already addressed - should see "No changes required"
- [ ] Trigger workflow on a PR with actionable items - should see "Review feedback addressed"

Closes #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)