### PR TITLE
fix(enrichment): Handle NaN trade_count in Kraken data logging

### DIFF
--- a/src/api/kraken_data_client.py
+++ b/src/api/kraken_data_client.py
@@ -215,7 +215,8 @@ class KrakenDataClient:
             rows.append({
                 "timestamp": datetime.fromtimestamp(candle[0], tz=timezone.utc),
                 "vwap": Decimal(str(candle[5])) if candle[5] else None,
-                "trade_count": int(candle[7]) if candle[7] else None,
+                # Use 'is not None' to preserve 0 as valid trade count
+                "trade_count": int(candle[7]) if candle[7] is not None else None,
             })
 
         return pd.DataFrame(rows)

--- a/src/daemon/runner.py
+++ b/src/daemon/runner.py
@@ -1338,10 +1338,13 @@ class TradingDaemon:
                 limit=self.settings.candle_limit,
             )
             if enrichment_df is not None and not enrichment_df.empty:
+                # Safely extract values, guarding against NaN
+                vwap_val = enrichment_df["vwap"].iloc[-1] if "vwap" in enrichment_df.columns else None
+                trade_count_val = enrichment_df["trade_count"].iloc[-1] if "trade_count" in enrichment_df.columns else None
                 logger.debug(
                     "enrichment_data_fetched",
-                    vwap=float(enrichment_df["vwap"].iloc[-1]) if "vwap" in enrichment_df.columns else None,
-                    trade_count=int(enrichment_df["trade_count"].iloc[-1]) if "trade_count" in enrichment_df.columns else None,
+                    vwap=float(vwap_val) if vwap_val is not None and pd.notna(vwap_val) else None,
+                    trade_count=int(trade_count_val) if trade_count_val is not None and pd.notna(trade_count_val) else None,
                 )
 
         # Calculate signal with HTF context, sentiment, and enrichment data

--- a/tests/test_kraken_data_client.py
+++ b/tests/test_kraken_data_client.py
@@ -190,6 +190,39 @@ class TestKrakenDataClient:
 
         assert len(self.client._cache) == 0
 
+    @patch("requests.Session.get")
+    def test_zero_trade_count_preserved(self, mock_get):
+        """Test that zero trade count is preserved (not treated as None).
+
+        Regression test: 'if candle[7]' falsely treated 0 as None.
+        """
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "result": {
+                "XXBTZUSD": [
+                    # Trade count is 0 - should be preserved, not converted to None/NaN
+                    [1704067200, "42000", "42100", "41900", "42050", "42025.5", "100", 0],
+                    # Trade count is None - should become None
+                    [1704067260, "42050", "42150", "41950", "42100", "42075.5", "50", None],
+                    # Normal trade count
+                    [1704067320, "42100", "42200", "42000", "42150", "42125.5", "75", 25],
+                ]
+            }
+        }
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        result = self.client._fetch_ohlc_data("BTC-USD", "ONE_HOUR", 100)
+
+        assert result is not None
+        assert len(result) == 3
+        # Zero should be preserved as 0.0 (float due to NaN in column), not NaN
+        assert result["trade_count"].iloc[0] == 0
+        # None should become NaN
+        assert pd.isna(result["trade_count"].iloc[1])
+        # Normal value should work
+        assert result["trade_count"].iloc[2] == 25
+
 
 class TestEnrichmentCache:
     """Tests for EnrichmentCache dataclass."""


### PR DESCRIPTION
## Summary
- Fix zero `trade_count` being incorrectly treated as `None` due to falsy check (`if candle[7]` → `if candle[7] is not None`)
- Add `pd.notna()` guard before `int()` conversion in runner logging to prevent crash
- Add regression test `test_zero_trade_count_preserved` to verify fix

## Root Cause
The error `'cannot convert float NaN to integer'` occurred because:
1. `kraken_data_client.py` used `if candle[7]` which treated `0` as falsy, converting valid zero trade counts to `None`
2. Pandas stores `None` in numeric columns as `NaN` (float)
3. `runner.py` called `int(trade_count_val)` without checking for `NaN`

## Test plan
- [x] Run full test suite (`python3 -m pytest tests/ -v`) - 1169 passed
- [x] New regression test verifies zero trade counts are preserved
- [x] Verified existing Kraken/enrichment tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)