### PR TITLE
fix(api): map unsupported Kraken intervals to nearest supported

### DIFF
--- a/src/api/symbol_mapper.py
+++ b/src/api/symbol_mapper.py
@@ -189,20 +189,33 @@ def parse_trading_pair(symbol: str) -> Tuple[str, str]:
 
 
 # Granularity mapping between our format and Kraken's
+# Kraken only supports: 1, 5, 15, 30, 60, 240, 1440, 10080 minute intervals
+# Unsupported intervals are mapped to nearest supported interval
 KRAKEN_GRANULARITY_MAP = {
     "ONE_MINUTE": 1,
     "FIVE_MINUTE": 5,
     "FIFTEEN_MINUTE": 15,
     "THIRTY_MINUTE": 30,
     "ONE_HOUR": 60,
-    "TWO_HOUR": 120,
+    "TWO_HOUR": 60,       # Kraken doesn't support 120, use 60 (1 hour)
     "FOUR_HOUR": 240,
-    "SIX_HOUR": 360,
+    "SIX_HOUR": 240,      # Kraken doesn't support 360, use 240 (4 hour)
     "ONE_DAY": 1440,
     "ONE_WEEK": 10080,
 }
 
-KRAKEN_GRANULARITY_REVERSE = {v: k for k, v in KRAKEN_GRANULARITY_MAP.items()}
+# Reverse map uses canonical intervals only (not fallbacks)
+# When Kraken returns 60, we interpret as ONE_HOUR (not TWO_HOUR which is a fallback)
+KRAKEN_GRANULARITY_REVERSE = {
+    1: "ONE_MINUTE",
+    5: "FIVE_MINUTE",
+    15: "FIFTEEN_MINUTE",
+    30: "THIRTY_MINUTE",
+    60: "ONE_HOUR",
+    240: "FOUR_HOUR",
+    1440: "ONE_DAY",
+    10080: "ONE_WEEK",
+}
 
 
 def to_kraken_granularity(granularity: str) -> int:


### PR DESCRIPTION
## Summary

- Fix Kraken OHLC API errors when using TWO_HOUR or SIX_HOUR candle intervals
- Map unsupported intervals to nearest Kraken-supported intervals
- Fix reverse mapping to use canonical intervals only

## Problem

Kraken's OHLC API only supports specific intervals: 1, 5, 15, 30, 60, 240, 1440, 10080 minutes. When using `CANDLE_INTERVAL=TWO_HOUR` (120 minutes), the Kraken data enrichment client was passing `interval=120` directly to the API, causing:

```
enrichment_fetch_failed error='Kraken API error: EGeneral:Invalid arguments'
```

## Solution

Map unsupported intervals to nearest supported ones in `symbol_mapper.py`:
- `TWO_HOUR` (120) → 60 (ONE_HOUR)
- `SIX_HOUR` (360) → 240 (FOUR_HOUR)

Also fixed the reverse mapping (`KRAKEN_GRANULARITY_REVERSE`) to use explicit canonical intervals, preventing dict collision where both `ONE_HOUR` and `TWO_HOUR` would map to `60`.

## Test plan

- [x] Verified Kraken API accepts interval=60 for BTC-EUR pair
- [x] All 1078 tests pass (excluding pre-existing database test config issues)
- [x] `test_from_kraken_granularity` passes with explicit reverse map