### PR TITLE
fix(notifications): escape HTML in AI text and fix dropped Telegram messages

### DIFF
--- a/src/daemon/runner.py
+++ b/src/daemon/runner.py
@@ -2885,7 +2885,7 @@ class TradingDaemon:
                         profit_percent=str(profit_pct),
                     )
 
-                    self.notifier.send_message(
+                    self.notifier.send_message_sync(
                         f"🎯 Take Profit Target Reached\n"
                         f"Entry: ¤{entry_price:,.2f} | Exit: ¤{current_price:,.2f} (+{profit_pct}%)\n"
                         f"Target: ¤{take_profit:,.2f}"
@@ -2927,7 +2927,7 @@ class TradingDaemon:
                         breakeven_multiplier=str(breakeven_multiplier),
                         atr=str(atr),
                     )
-                    self.notifier.send_message(
+                    self.notifier.send_message_sync(
                         f"🛡️ Break-even protection activated\n"
                         f"Entry: ¤{entry_price:,.2f} | Current: ¤{current_price:,.2f} (+{profit_pct}%)\n"
                         f"Position now protected at entry"

--- a/src/daemon/runner.py
+++ b/src/daemon/runner.py
@@ -789,7 +789,7 @@ class TradingDaemon:
                     "config_change_requires_restart",
                     fields=list(ignored_changes),
                 )
-                self.notifier.send_message(
+                self.notifier.send_message_sync(
                     f"Warning: {', '.join(ignored_changes)} changes require restart"
                 )
 
@@ -892,7 +892,7 @@ class TradingDaemon:
             )
 
             # Notify via Telegram
-            self.notifier.send_message(
+            self.notifier.send_message_sync(
                 f"Config reloaded: {', '.join(changes.keys())} updated"
             )
 
@@ -976,7 +976,7 @@ class TradingDaemon:
                         # Extract URL from output
                         for line in result.stdout.split("\n"):
                             if "github.com" in line and "discussions" in line:
-                                self.notifier.send_message(f"📊 Post-mortem analysis: {line.strip()}")
+                                self.notifier.send_message_sync(f"📊 Post-mortem analysis: {line.strip()}")
                                 break
                 else:
                     logger.warning(
@@ -1959,7 +1959,7 @@ class TradingDaemon:
                             )
                             if should_notify:
                                 self._last_ai_failure_notification = now
-                                self.notifier.send_message(
+                                self.notifier.send_message_sync(
                                     f"⚠️ Trade skipped: AI review unavailable\n"
                                     f"Signal: {effective_action} (score: {signal_result.score})"
                                 )
@@ -2842,7 +2842,7 @@ class TradingDaemon:
                 # Send hard stop notification with missed TP target
                 take_profit = ts.get_take_profit_price()
                 tp_info = f" | TP Target: ¤{take_profit:,.2f}" if take_profit else ""
-                self.notifier.send_message(
+                self.notifier.send_message_sync(
                     f"🛑 Hard Stop Triggered (-{loss_pct}%)\n"
                     f"Entry: ¤{entry_price:,.2f} | Exit: ¤{current_price:,.2f}\n"
                     f"Stop: ¤{hard_stop:,.2f}{tp_info}"

--- a/src/notifications/telegram.py
+++ b/src/notifications/telegram.py
@@ -17,6 +17,7 @@ Features:
 
 import asyncio
 import hashlib
+import html
 import re
 from datetime import datetime, timezone
 from decimal import Decimal
@@ -180,6 +181,15 @@ class TelegramNotifier:
                 return False
 
         return True
+
+    @staticmethod
+    def _escape_html(text: str) -> str:
+        """Escape HTML special characters in AI-generated text.
+
+        AI models may output text containing <, >, or & characters
+        (e.g., <thinking>, <analysis>) which break Telegram's HTML parser.
+        """
+        return html.escape(str(text))
 
     def _record_sent(self, msg_type: str, message: str) -> None:
         """Record that a message was sent for deduplication."""
@@ -830,7 +840,7 @@ class TelegramNotifier:
                 summary = getattr(agent, 'summary', None) or agent.reasoning[:80]
                 agent_lines.append(
                     f"{stance_emoji.get(agent.stance, '⚪')} <b>{model_short}</b> ({stance_label}): "
-                    f"{verdict} {conf}\n  <i>{summary}</i>"
+                    f"{verdict} {conf}\n  <i>{self._escape_html(summary)}</i>"
                 )
             agents_text = "\n\n".join(agent_lines) if agent_lines else "No reviews"
 
@@ -860,7 +870,7 @@ class TelegramNotifier:
                 f"<b>━━━ Judge Decision ━━━</b>\n"
                 f"{judge_decision_text} ({review.judge_confidence*100:.0f}% confidence)\n"
                 f"{rec_emoji.get(recommendation, '📌')} Recommendation: <b>{rec_text.get(recommendation, recommendation.upper())}</b>\n\n"
-                f"<i>{review.judge_reasoning}</i>\n\n"
+                f"<i>{self._escape_html(review.judge_reasoning)}</i>\n\n"
                 f"Time: {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S')}"
             )
         else:
@@ -885,7 +895,7 @@ class TelegramNotifier:
                 summary = getattr(agent, 'summary', None) or agent.reasoning[:80]
                 agent_lines.append(
                     f"{stance_emoji.get(agent.stance, '⚪')} <b>{model_short}</b> ({stance_label}): "
-                    f"{verdict} {conf}\n  <i>{summary}</i>"
+                    f"{verdict} {conf}\n  <i>{self._escape_html(summary)}</i>"
                 )
 
             agents_text = "\n\n".join(agent_lines) if agent_lines else "  No agent reviews"
@@ -983,7 +993,7 @@ class TelegramNotifier:
                 f"<b>━━━ Judge Decision ━━━</b>\n"
                 f"{judge_decision_text} ({review.judge_confidence*100:.0f}% confidence)\n"
                 f"{rec_emoji.get(recommendation, '📌')} Recommendation: <b>{rec_text.get(recommendation, recommendation.upper())}</b>\n\n"
-                f"<i>{review.judge_reasoning}</i>"
+                f"<i>{self._escape_html(review.judge_reasoning)}</i>"
                 f"{veto_text}\n\n"
                 f"{outcome}\n\n"
                 f"Time: {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S')}"
@@ -1117,7 +1127,7 @@ class TelegramNotifier:
             f"{profile_emoji} <b>Weight Profile Changed</b>\n\n"
             f"<b>Profile:</b> {old_profile} → {new_profile}\n"
             f"<b>Confidence:</b> {confidence_pct}%\n\n"
-            f"<b>AI Reasoning:</b>\n{reasoning}"
+            f"<b>AI Reasoning:</b>\n{self._escape_html(reasoning)}"
         )
 
         if self.send_message_sync(message):
@@ -1232,7 +1242,7 @@ class TelegramNotifier:
             summary = getattr(agent, 'summary', None) or agent.reasoning[:80]
             agent_lines.append(
                 f"{stance_emoji.get(agent.stance, '⚪')} <b>{model_short}</b> ({stance_label}): "
-                f"{outlook} {conf}\n  <i>{summary}</i>"
+                f"{outlook} {conf}\n  <i>{self._escape_html(summary)}</i>"
             )
         agents_text = "\n\n".join(agent_lines) if agent_lines else "No reviews"
 
@@ -1256,7 +1266,7 @@ class TelegramNotifier:
             f"<b>━━━ Judge Synthesis ━━━</b>\n"
             f"Confidence: {review.judge_confidence*100:.0f}%\n"
             f"{rec_emoji.get(recommendation, '📌')} Recommendation: <b>{rec_text.get(recommendation, recommendation.upper())}</b>\n\n"
-            f"<i>{review.judge_reasoning}</i>\n\n"
+            f"<i>{self._escape_html(review.judge_reasoning)}</i>\n\n"
             f"Time: {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S')}"
         )
 

--- a/tests/test_trading_daemon.py
+++ b/tests/test_trading_daemon.py
@@ -955,7 +955,7 @@ def test_ai_failure_mode_open_does_not_skip_trade(mock_settings, mock_exchange_c
                 # focuses on the AI failure handling behavior, not the complete trade path.
                 # The trade may not execute due to other conditions (order sizing, etc.)
                 notifier_instance = mock_notifier.return_value
-                for call in notifier_instance.send_message.call_args_list:
+                for call in notifier_instance.send_message_sync.call_args_list:
                     msg = str(call)
                     assert "Trade skipped" not in msg, "OPEN mode should not skip trades"
 
@@ -1053,7 +1053,7 @@ def test_ai_failure_mode_safe_skips_trade(mock_settings, mock_exchange_client, m
 
                 # Verify notification was sent about skipped trade
                 notifier_instance = mock_notifier.return_value
-                notifier_instance.send_message.assert_called()
+                notifier_instance.send_message_sync.assert_called()
 
 
 def test_ai_failure_mode_defaults(mock_settings, mock_exchange_client, mock_database):
@@ -1148,7 +1148,7 @@ def test_ai_failure_mode_sell_proceeds_on_failure(mock_settings, mock_exchange_c
 
                 # CRITICAL: Verify sell was NOT skipped (negative assertion)
                 notifier_instance = mock_notifier.return_value
-                for call in notifier_instance.send_message.call_args_list:
+                for call in notifier_instance.send_message_sync.call_args_list:
                     msg = str(call)
                     assert "Trade skipped" not in msg, "SELL with OPEN mode should not skip trades"
 
@@ -1238,7 +1238,7 @@ def test_ai_failure_mode_sell_safe_skips_trade(mock_settings, mock_exchange_clie
                 # Verify notification was sent about skipped trade
                 notifier_instance = mock_notifier.return_value
                 skip_notification_sent = False
-                for call in notifier_instance.send_message.call_args_list:
+                for call in notifier_instance.send_message_sync.call_args_list:
                     msg = str(call)
                     if "Trade skipped" in msg or "AI review failed" in msg:
                         skip_notification_sent = True
@@ -1333,22 +1333,22 @@ def test_ai_failure_notification_cooldown(mock_settings, mock_exchange_client, m
 
                 # First failure: should send notification
                 daemon._trading_iteration()
-                assert notifier_instance.send_message.call_count == 1
+                assert notifier_instance.send_message_sync.call_count == 1
 
                 # Second failure immediately after: should NOT send notification (cooldown)
                 daemon._trading_iteration()
-                assert notifier_instance.send_message.call_count == 1  # Still 1, not 2
+                assert notifier_instance.send_message_sync.call_count == 1  # Still 1, not 2
 
                 # Third failure immediately after: should still NOT send notification
                 daemon._trading_iteration()
-                assert notifier_instance.send_message.call_count == 1  # Still 1, not 3
+                assert notifier_instance.send_message_sync.call_count == 1  # Still 1, not 3
 
                 # Simulate 15 minutes passing by resetting the timestamp (use timezone-aware UTC)
                 daemon._last_ai_failure_notification = datetime.now(timezone.utc) - timedelta(minutes=16)
 
                 # Fourth failure after cooldown: should send notification again
                 daemon._trading_iteration()
-                assert notifier_instance.send_message.call_count == 2  # Now 2
+                assert notifier_instance.send_message_sync.call_count == 2  # Now 2
 
 
 # ============================================================================

--- a/tests/test_trading_daemon.py
+++ b/tests/test_trading_daemon.py
@@ -3399,7 +3399,7 @@ def test_take_profit_triggers_at_target_price(mock_settings):
 
                 assert result == "sell", "Take profit should return 'sell' when price reaches target"
                 mock_database.deactivate_trailing_stop.assert_called_once()
-                mock_notifier.send_message.assert_called()  # TP notification sent
+                mock_notifier.send_message_sync.assert_called()  # TP notification sent
 
 
 def test_take_profit_triggers_above_target_price(mock_settings):
@@ -3510,7 +3510,7 @@ def test_hard_stop_has_priority_over_take_profit(mock_settings):
 
                 assert result == "sell", "Hard stop should trigger"
                 # Check that it was hard stop notification, not TP
-                call_args = mock_notifier.send_message.call_args[0][0]
+                call_args = mock_notifier.send_message_sync.call_args[0][0]
                 assert "Hard Stop" in call_args, "Should be hard stop notification"
 
 
@@ -3714,7 +3714,7 @@ def test_take_profit_priority_over_trailing_in_gap(mock_settings):
 
                 assert result == "sell", "Should trigger sell"
                 # Verify it was TP notification (checked first due to priority)
-                call_args = mock_notifier.send_message.call_args[0][0]
+                call_args = mock_notifier.send_message_sync.call_args[0][0]
                 assert "Take Profit" in call_args, "Should be TP notification, not trailing stop"
 
 


### PR DESCRIPTION
cc @TheodorStorm 
## Summary

AI models sometimes return text with angle brackets (like `<thinking>` or `<analysis>` tags) in their reasoning. Since Telegram messages use HTML parse mode, these get interpreted as malformed HTML tags and the API rejects the entire message. This was causing trade review and market analysis notifications to silently fail.

Separately, several notification calls in `runner.py` used the async `send_message()` instead of the synchronous `send_message_sync()` wrapper. Because the daemon's main loop isn't async, these coroutines were never awaited -- Python logged a RuntimeWarning and the messages were quietly dropped.

## What changed

**`src/notifications/telegram.py`:**
- Added `_escape_html()` method using `html.escape()` to sanitize AI-generated text
- Applied it to all agent summaries and judge reasoning before they get inserted into `<i>` tags
- Affects: trade reviews, hold reviews, market analysis, weight profile notifications

**`src/daemon/runner.py`:**
- Changed 7 `send_message()` calls to `send_message_sync()` -- this covers take profit, break-even, hard stop, config reload, post-mortem, and AI failure skip notifications

**`tests/test_trading_daemon.py`:**
- Updated mock assertions to match the `send_message_sync` calls

## Risk

Low. No changes to order execution, position sizing, or risk limits. The fix only affects how notification text is formatted and which wrapper method is called for sending. Both `send_message` and `send_message_sync` send the same Telegram message -- the sync version just handles the event loop correctly from non-async code.

## Testing

150 tests passed on the deployment target (Ubuntu 24.04, aarch64, Python 3.12). The pre-existing async test failures (missing pytest-asyncio) and whale boundary test are unrelated.